### PR TITLE
only load factories in test console

### DIFF
--- a/lib/database_helper.rb
+++ b/lib/database_helper.rb
@@ -103,8 +103,10 @@ module Citygram
 
     def self.console(ctx = self)
       require File.expand_path('../../app', __FILE__)
-      require 'factory_girl'
-      require File.join(app_root, 'spec/factories')
+      if ENV['RACK_ENV'] == 'test'
+        require 'factory_girl'
+        require File.join(app_root, 'spec/factories')
+      end
       ctx.send :include, FactoryGirl::Syntax::Methods
       require 'irb'
       ARGV.clear

--- a/lib/database_helper.rb
+++ b/lib/database_helper.rb
@@ -106,8 +106,8 @@ module Citygram
       if ENV['RACK_ENV'] == 'test'
         require 'factory_girl'
         require File.join(app_root, 'spec/factories')
+        ctx.send :include, FactoryGirl::Syntax::Methods
       end
-      ctx.send :include, FactoryGirl::Syntax::Methods
       require 'irb'
       ARGV.clear
       IRB.start


### PR DESCRIPTION
If you're looking to run the console on production it will fail with

```
codeforamerica [!?$]
$ heroku run rake console -a citygram-nyc-codeforamerica
Running `rake console` attached to terminal... up, run.7905
rake aborted!
LoadError: cannot load such file -- factory_girl
/app/lib/database_helper.rb:106:in `require'
/app/lib/database_helper.rb:106:in `console'
/app/lib/tasks/database.rake:5:in `block in <top (required)>'
Tasks: TOP => console
(See full trace by running task with --trace)
```

This works around that by checking for a test env before requiring FactorGirl.

```
test-console-factory-girl [!?$]
$ git push citygram-nyc-codeforamerica test-console-factory-girl:master
Fetching repository, done.
Counting objects: 4, done.
```

```
test-console-factory-girl [!?$]
$ heroku run rake console -a citygram-nyc-codeforamerica
Running `rake console` attached to terminal... up, run.9242
irb(main):001:0>
```