### PR TITLE
Update README.md - rbenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Citygram is a web application written in Ruby.
 
 * Install Redis - `brew install redis`
 * [Install PostgreSQL](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md)
-* [Install Ruby](https://github.com/codeforamerica/howto/blob/master/Ruby.md)
+* Install Ruby ([rbenv guide](https://github.com/sstephenson/rbenv#installation))
 
 In the command line, run the following:
 


### PR DESCRIPTION
Removed link to cfa install guide, moved to rbenv (which is used further on in the readme) Closes #73