### PR TITLE
Mention PostGIS when saying PostgreSQL is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Citygram is a web application written in Ruby.
 ### Setup
 
 * Install Redis - `brew install redis`
-* [Install PostgreSQL](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md)
+* [Install PostgreSQL (with PostGIS extensions)](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md)
 * Install Ruby ([rbenv guide](https://github.com/sstephenson/rbenv#installation))
 
 In the command line, run the following:


### PR DESCRIPTION
I prefer to manage my own PostgreSQL installation rather than using the Mac.App and I would have been 100% setup and ready following the instructions if only I knew PostGIS was needed